### PR TITLE
fix(scripts): update scripts so server and webpack both start correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Example of using react-simple-maps to create a basic world map.",
   "main": "index.js",
   "scripts": {
-    "start": "http-server",
-    "build": "webpack --config webpack.config.js",
-    "test": "webpack --config webpack.config.js && http-server ./public -c-1"
+    "start-server": "http-server ./public -c-1",
+    "build-client-watch": "webpack -w",
+    "start-dev": "npm run build-client-watch & npm run start-server"
   },
   "keywords": [],
   "author": "Team-Pandemic",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,5 +21,4 @@ module.exports = {
       }
     ]
   },
-  watch: true
 };


### PR DESCRIPTION
The webpack script must be started with an ampersand so it runs in the background, allowing the start-server script to be executed. 